### PR TITLE
Use whoami instead of id -u to check current user ID

### DIFF
--- a/starter-arbitrary-uid/bin/uid_entrypoint
+++ b/starter-arbitrary-uid/bin/uid_entrypoint
@@ -1,9 +1,7 @@
 #!/bin/sh
-if [ -w /etc/passwd ]; then 
-  USER_ID=$(id -u)
-  id ${USER_ID} &> /dev/null
-  if [ $? -ne 0 ]; then
-    sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:${USER_ID}:@g" /etc/passwd.template > /etc/passwd
+if [ -w /etc/passwd ]; then
+  if ! whoami &> /dev/null; then
+    sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:$(id -u):@g" /etc/passwd.template > /etc/passwd
   fi
 fi
 exec "$@"

--- a/starter-systemd/bin/systemd_entrypoint
+++ b/starter-systemd/bin/systemd_entrypoint
@@ -1,9 +1,7 @@
 #!/bin/sh
-if [ -w /etc/passwd ]; then 
-  USER_ID=$(id -u)
-  id ${USER_ID} &> /dev/null
-  if [ $? -ne 0 ]; then
-    sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:${USER_ID}:@g" /etc/passwd.template > /etc/passwd
+if [ -w /etc/passwd ]; then
+  if ! whoami &> /dev/null; then
+    sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:$(id -u):@g" /etc/passwd.template > /etc/passwd
   fi
 fi
 exec /usr/lib/systemd/systemd-starter


### PR DESCRIPTION
Replace the check of the current UID based on `id -u` with `whoami` to make the purpose of the check a bit more clear / intuitive: *do I know who am I?*

