### PR TITLE
test improvements for openshift use-cases

### DIFF
--- a/starter-arbitrary-uid/Dockerfile
+++ b/starter-arbitrary-uid/Dockerfile
@@ -55,4 +55,5 @@ ENTRYPOINT [ "uid_entrypoint" ]
 ### Containers should NOT run as root as a good practice
 USER 10001
 WORKDIR ${APP_ROOT}
+VOLUME ${APP_ROOT}/logs ${APP_ROOT}/data
 CMD run

--- a/starter-arbitrary-uid/Dockerfile.centos7
+++ b/starter-arbitrary-uid/Dockerfile.centos7
@@ -37,4 +37,5 @@ ENTRYPOINT [ "uid_entrypoint" ]
 ### Containers should NOT run as root as a good practice
 USER 10001
 WORKDIR ${APP_ROOT}
+VOLUME ${APP_ROOT}/logs ${APP_ROOT}/data
 CMD run

--- a/starter-arbitrary-uid/Makefile
+++ b/starter-arbitrary-uid/Makefile
@@ -23,7 +23,12 @@ lint:
 	dockerfile_lint -f Dockerfile.centos7
 
 test:
-	$(eval CONTAINERID=$(shell docker run -tdi -u $(shell shuf -i 1000010000-1000020000 -n 1) \
+	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
+	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2777,gid=${ARB_UID}"; done; echo $${VOLS}))
+	$(eval CONTAINERID=$(shell docker run -tdi \
+	-u ${ARB_UID} --group-add ${ARB_UID} \
+	${TMPFS} \
 	--cap-drop=KILL \
 	--cap-drop=MKNOD \
 	--cap-drop=SYS_CHROOT \
@@ -31,9 +36,16 @@ test:
 	--cap-drop=SETGID \
 	${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
 	@sleep 3
-	@docker exec ${CONTAINERID} ps aux
-	@docker exec ${CONTAINERID} whoami
-	@docker rm -f ${CONTAINERID}
+	@echo "View processes..."
+	docker exec ${CONTAINERID} ps aux
+	@echo ""
+	@echo "Check id information..."
+	docker exec ${CONTAINERID} id
+	docker exec ${CONTAINERID} whoami
+	@echo ""
+	@echo "Check volume(s)..."
+	@for i in ${VOL_LIST}; do docker exec ${CONTAINERID} mountpoint $${i}; docker exec ${CONTAINERID} mount | grep -w $${i} | grep tmpfs; echo; done
+	@docker rm -vf ${CONTAINERID}
 
 openshift-test:
 	$(eval PROJ_RANDOM=test-$(shell shuf -i 100000-999999 -n 1))
@@ -51,7 +63,12 @@ openshift-test:
 	oc exec `oc get pod --template '{{(index .items 0).metadata.name }}'` whoami
 
 run:
-	docker run -tdi -u $(shell shuf -i 1000010000-1000020000 -n 1) \
+	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
+	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2777,gid=${ARB_UID}"; done; echo $${VOLS}))
+	docker run -tdi \
+	-u ${ARB_UID} --group-add ${ARB_UID} \
+	${TMPFS} \
 	--cap-drop=KILL \
 	--cap-drop=MKNOD \
 	--cap-drop=SYS_CHROOT \

--- a/starter-arbitrary-uid/Makefile
+++ b/starter-arbitrary-uid/Makefile
@@ -23,9 +23,11 @@ lint:
 	dockerfile_lint -f Dockerfile.centos7
 
 test:
+#	OpenShift compatibility - assign an arbitrary uid
 	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
+#	OpenShift compatibility - prepare for mount of specified VOLUMEs in image
 	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
-	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2777,gid=${ARB_UID}"; done; echo $${VOLS}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
 	$(eval CONTAINERID=$(shell docker run -tdi \
 	-u ${ARB_UID} --group-add ${ARB_UID} \
 	${TMPFS} \
@@ -65,7 +67,7 @@ openshift-test:
 run:
 	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
 	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
-	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2777,gid=${ARB_UID}"; done; echo $${VOLS}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
 	docker run -tdi \
 	-u ${ARB_UID} --group-add ${ARB_UID} \
 	${TMPFS} \

--- a/starter-arbitrary-uid/Makefile
+++ b/starter-arbitrary-uid/Makefile
@@ -27,7 +27,7 @@ test:
 	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
 #	OpenShift compatibility - prepare for mount of specified VOLUMEs in image
 	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
-	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:rw,suid,dev,exec,relatime,mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
 	$(eval CONTAINERID=$(shell docker run -tdi \
 	-u ${ARB_UID} --group-add ${ARB_UID} \
 	${TMPFS} \
@@ -67,7 +67,7 @@ openshift-test:
 run:
 	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
 	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
-	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:rw,suid,dev,exec,relatime,mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
 	docker run -tdi \
 	-u ${ARB_UID} --group-add ${ARB_UID} \
 	${TMPFS} \

--- a/starter-systemd/Makefile
+++ b/starter-systemd/Makefile
@@ -28,7 +28,7 @@ lint:
 test:
 #	OpenShift compatibility - prepare for mount of specified VOLUMEs in image
 	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
-	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}"; done; echo $${VOLS}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:rw,suid,dev,exec,relatime,mode=2770"; done; echo $${VOLS}))
 	$(eval CONTAINERID=$(shell docker run -tdi \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	${TMPFS} \
@@ -68,7 +68,7 @@ openshift-test:
 
 run:
 	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
-	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}"; done; echo $${VOLS}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:rw,suid,dev,exec,relatime,mode=2770"; done; echo $${VOLS}))
 	docker run -tdi -p 8080:80 \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	${TMPFS} \

--- a/starter-systemd/Makefile
+++ b/starter-systemd/Makefile
@@ -26,14 +26,25 @@ lint:
 	dockerfile_lint -f Dockerfile.w-postgresql
 
 test:
-	$(eval CONTAINERID=$(shell docker run -tdi -v /sys/fs/cgroup:/sys/fs/cgroup:ro --tmpfs /run --tmpfs /tmp \
+	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}"; done; echo $${VOLS}))
+	$(eval CONTAINERID=$(shell docker run -tdi \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+	${TMPFS} \
 	--cap-drop=MKNOD \
 	--cap-drop=SYS_CHROOT \
 	${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
 	@sleep 3
+	@echo ""
+	@echo "Check httpd..."
 	@docker exec ${CONTAINERID} curl localhost
+	@echo ""
+	@echo "Check systemd state..."
 	@docker exec ${CONTAINERID} systemctl status
-	@docker rm -f ${CONTAINERID}
+	@echo ""
+	@echo "Check volume(s)..."
+	@for i in ${VOL_LIST}; do docker exec ${CONTAINERID} mountpoint $${i}; docker exec ${CONTAINERID} mount | grep -w $${i} | grep tmpfs; echo; done
+	@docker rm -vf ${CONTAINERID}
 
 openshift-test:
 	$(eval PROJ_RANDOM=test-$(shell shuf -i 100000-999999 -n 1))
@@ -55,7 +66,11 @@ openshift-test:
 	oc exec `oc describe pod ${IMAGE_NAME}-2- | grep ^Name\: | grep ${IMAGE_NAME}-2- | sed 's/^.*://g' | tr -d ' \t\n\r\f'` systemctl status
 
 run:
-	docker run -tdi -p 8080:80 -v /sys/fs/cgroup:/sys/fs/cgroup:ro --tmpfs /run --tmpfs /tmp \
+	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}"; done; echo $${VOLS}))
+	docker run -tdi -p 8080:80 \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+	${TMPFS} \
 	--cap-drop=MKNOD \
 	--cap-drop=SYS_CHROOT \
 	${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}

--- a/starter-systemd/Makefile
+++ b/starter-systemd/Makefile
@@ -26,6 +26,7 @@ lint:
 	dockerfile_lint -f Dockerfile.w-postgresql
 
 test:
+#	OpenShift compatibility - prepare for mount of specified VOLUMEs in image
 	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
 	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}"; done; echo $${VOLS}))
 	$(eval CONTAINERID=$(shell docker run -tdi \

--- a/starter/Dockerfile
+++ b/starter/Dockerfile
@@ -50,4 +50,5 @@ RUN chmod -R ug+x ${APP_ROOT}/bin && sync && \
 ### Containers should NOT run as root as a good practice
 USER 10001
 WORKDIR ${APP_ROOT}
+VOLUME ${APP_ROOT}/logs ${APP_ROOT}/data
 CMD run

--- a/starter/Dockerfile.centos7
+++ b/starter/Dockerfile.centos7
@@ -32,4 +32,5 @@ RUN chmod -R ug+x ${APP_ROOT}/bin && sync && \
 ### Containers should NOT run as root as a good practice
 USER 10001
 WORKDIR ${APP_ROOT}
+VOLUME ${APP_ROOT}/logs ${APP_ROOT}/data
 CMD run

--- a/starter/Makefile
+++ b/starter/Makefile
@@ -27,7 +27,7 @@ test:
 	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
 #	OpenShift compatibility - prepare for mount of specified VOLUMEs in image
 	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
-	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:rw,suid,dev,exec,relatime,mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
 	$(eval CONTAINERID=$(shell docker run -tdi \
 	-u ${ARB_UID} --group-add ${ARB_UID} \
 	${TMPFS} \
@@ -65,7 +65,7 @@ openshift-test:
 run:
 	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
 	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
-	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:rw,suid,dev,exec,relatime,mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
 	docker run -tdi \
 	-u ${ARB_UID} --group-add ${ARB_UID} \
 	${TMPFS} \

--- a/starter/Makefile
+++ b/starter/Makefile
@@ -23,7 +23,12 @@ lint:
 	dockerfile_lint -f Dockerfile.centos7
 
 test:
-	$(eval CONTAINERID=$(shell docker run -tdi -u $(shell shuf -i 1000010000-1000020000 -n 1) \
+	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
+	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2777,gid=${ARB_UID}"; done; echo $${VOLS}))
+	$(eval CONTAINERID=$(shell docker run -tdi \
+	-u ${ARB_UID} --group-add ${ARB_UID} \
+	${TMPFS} \
 	--cap-drop=KILL \
 	--cap-drop=MKNOD \
 	--cap-drop=SYS_CHROOT \
@@ -31,8 +36,15 @@ test:
 	--cap-drop=SETGID \
 	${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
 	@sleep 3
-	@docker exec ${CONTAINERID} ps aux
-	@docker rm -f ${CONTAINERID}
+	@echo "View processes..."
+	docker exec ${CONTAINERID} ps aux
+	@echo ""
+	@echo "Check id information..."
+	docker exec ${CONTAINERID} id
+	@echo ""
+	@echo "Check volume(s)..."
+	@for i in ${VOL_LIST}; do docker exec ${CONTAINERID} mountpoint $${i}; docker exec ${CONTAINERID} mount | grep -w $${i} | grep tmpfs; echo; done
+	@docker rm -vf ${CONTAINERID}
 
 openshift-test:
 	$(eval PROJ_RANDOM=test-$(shell shuf -i 100000-999999 -n 1))
@@ -49,7 +61,12 @@ openshift-test:
 	oc exec `oc get pod --template '{{(index .items 0).metadata.name }}'` ps aux
 
 run:
-	docker run -tdi -u $(shell shuf -i 1000010000-1000020000 -n 1) \
+	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
+	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2777,gid=${ARB_UID}"; done; echo $${VOLS}))
+	docker run -tdi \
+	-u ${ARB_UID} --group-add ${ARB_UID} \
+	${TMPFS} \
 	--cap-drop=KILL \
 	--cap-drop=MKNOD \
 	--cap-drop=SYS_CHROOT \

--- a/starter/Makefile
+++ b/starter/Makefile
@@ -23,9 +23,11 @@ lint:
 	dockerfile_lint -f Dockerfile.centos7
 
 test:
+#	OpenShift compatibility - assign an arbitrary uid
 	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
+#	OpenShift compatibility - prepare for mount of specified VOLUMEs in image
 	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
-	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2777,gid=${ARB_UID}"; done; echo $${VOLS}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
 	$(eval CONTAINERID=$(shell docker run -tdi \
 	-u ${ARB_UID} --group-add ${ARB_UID} \
 	${TMPFS} \
@@ -63,7 +65,7 @@ openshift-test:
 run:
 	$(eval ARB_UID=$(shell shuf -i 1000010000-1000020000 -n 1))
 	$(eval VOL_LIST=$(shell docker inspect -f '{{range $$p, $$vol := .Config.Volumes}} {{json $$p}} {{end}}' ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
-	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2777,gid=${ARB_UID}"; done; echo $${VOLS}))
+	$(eval TMPFS=$(shell for i in ${VOL_LIST}; do VOLS="$${VOLS} --tmpfs $${i}:mode=2770,gid=${ARB_UID}"; done; echo $${VOLS}))
 	docker run -tdi \
 	-u ${ARB_UID} --group-add ${ARB_UID} \
 	${TMPFS} \


### PR DESCRIPTION
 - with `make test`, account for openshift specific tests
 - dynamically mount tmpfs volumes w/ gid & mode set accordingly
 - use --group-add of arb uid/gid